### PR TITLE
Add cxxopts and Catch2 only if needed.

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -31,3 +31,9 @@ function(warning_as_error TARGET_NAME)
             /WX /W4>
             )
 endfunction()
+
+macro(add_subdirectory_if_target_not_exists TARGET_NAME)
+    if (NOT TARGET ${TARGET_NAME})
+        add_subdirectory(${TARGET_NAME})
+    endif()
+endmacro()

--- a/externals/CMakeLists.txt
+++ b/externals/CMakeLists.txt
@@ -1,5 +1,5 @@
-add_subdirectory(cxxopts)
+add_subdirectory_if_target_not_exists(cxxopts)
 
 if (RESCOM_TEST)
-add_subdirectory(Catch2)
+    add_subdirectory_if_target_not_exists(Catch2)
 endif()


### PR DESCRIPTION
It's possible rescom be used as sub project of a project
using cxxopts or Catch2, in this case rescom use thoses.