### PR TITLE
Prevent rebuild if nothing changed since last run

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 
 cmake_minimum_required(VERSION 3.9)
 
-project(rescom VERSION 0.0.0)
+project(rescom VERSION 0.0.1)
 
 if (RESCOM_TEST)
     enable_testing()

--- a/externals/CMakeLists.txt
+++ b/externals/CMakeLists.txt
@@ -1,5 +1,8 @@
 add_subdirectory_if_target_not_exists(cxxopts)
 
+add_library(PicoSHA2 INTERFACE)
+target_include_directories(PicoSHA2 INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/PicoSHA2)
+
 if (RESCOM_TEST)
     add_subdirectory_if_target_not_exists(Catch2)
 endif()

--- a/externals/PicoSHA2/LICENSE
+++ b/externals/PicoSHA2/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017 okdshin
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/externals/PicoSHA2/README.md
+++ b/externals/PicoSHA2/README.md
@@ -1,0 +1,138 @@
+# PicoSHA2 - a C++ SHA256 hash generator
+
+Copyright &copy; 2017 okdshin
+
+## Introduction
+
+PicoSHA2 is a tiny SHA256 hash generator for C++ with following properties:
+
+- header-file only
+- no external dependencies (only uses standard C++ libraries)
+- STL-friendly
+- licensed under MIT License
+
+## Generating SHA256 hash and hash hex string
+
+```c++
+// any STL sequantial container (vector, list, dequeue...)
+std::string src_str = "The quick brown fox jumps over the lazy dog";
+
+std::vector<unsigned char> hash(picosha2::k_digest_size);
+picosha2::hash256(src_str.begin(), src_str.end(), hash.begin(), hash.end());
+
+std::string hex_str = picosha2::bytes_to_hex_string(hash.begin(), hash.end());
+```
+
+## Generating SHA256 hash and hash hex string from byte stream
+
+```c++
+picosha2::hash256_one_by_one hasher;
+...
+hasher.process(block.begin(), block.end());
+...
+hasher.finish();
+
+std::vector<unsigned char> hash(picosha2::k_digest_size);
+hasher.get_hash_bytes(hash.begin(), hash.end());
+
+std::string hex_str = picosha2::get_hash_hex_string(hasher);
+```
+
+The file `example/interactive_hasher.cpp` has more detailed information.
+
+## Generating SHA256 hash from a binary file
+
+```c++
+std::ifstream f("file.txt", std::ios::binary);
+std::vector<unsigned char> s(picosha2::k_digest_size);
+picosha2::hash256(f, s.begin(), s.end());
+```
+
+This `hash256` may use less memory than reading whole of the file.
+
+## Generating SHA256 hash hex string from std::string
+
+```c++
+std::string src_str = "The quick brown fox jumps over the lazy dog";
+std::string hash_hex_str;
+picosha2::hash256_hex_string(src_str, hash_hex_str);
+std::cout << hash_hex_str << std::endl;
+//this output is "d7a8fbb307d7809469ca9abcb0082e4f8d5651e46d3cdb762d02d0bf37c9e592"
+```
+
+```c++
+std::string src_str = "The quick brown fox jumps over the lazy dog";
+std::string hash_hex_str = picosha2::hash256_hex_string(src_str);
+std::cout << hash_hex_str << std::endl;
+//this output is "d7a8fbb307d7809469ca9abcb0082e4f8d5651e46d3cdb762d02d0bf37c9e592"
+```
+
+```c++
+std::string src_str = "The quick brown fox jumps over the lazy dog.";//add '.'
+std::string hash_hex_str = picosha2::hash256_hex_string(src_str.begin(), src_str.end());
+std::cout << hash_hex_str << std::endl;
+//this output is "ef537f25c895bfa782526529a9b63d97aa631564d5d789c2b765448c8635fb6c"
+```
+
+## Generating SHA256 hash hex string from byte sequence
+
+```c++
+std::vector<unsigned char> src_vect(...);
+std::string hash_hex_str;
+picosha2::hash256_hex_string(src_vect, hash_hex_str);
+```
+
+```c++
+std::vector<unsigned char> src_vect(...);
+std::string hash_hex_str = picosha2::hash256_hex_string(src_vect);
+```
+
+```c++
+unsigned char src_c_array[picosha2::k_digest_size] = {...};
+std::string hash_hex_str;
+picosha2::hash256_hex_string(src_c_array, src_c_array+picosha2::k_digest_size, hash_hex_str);
+```
+
+```c++
+unsigned char src_c_array[picosha2::k_digest_size] = {...};
+std::string hash_hex_str = picosha2::hash256_hex_string(src_c_array, src_c_array+picosha2::k_digest_size);
+```
+
+
+## Generating SHA256 hash byte sequence from STL sequential container
+
+```c++
+//any STL sequantial container (vector, list, dequeue...)
+std::string src_str = "The quick brown fox jumps over the lazy dog";
+
+//any STL sequantial containers (vector, list, dequeue...)
+std::vector<unsigned char> hash(picosha2::k_digest_size);
+
+// in: container, out: container
+picosha2::hash256(src_str, hash);
+```
+
+```c++
+//any STL sequantial container (vector, list, dequeue...)
+std::string src_str = "The quick brown fox jumps over the lazy dog";
+
+//any STL sequantial containers (vector, list, dequeue...)
+std::vector<unsigned char> hash(picosha2::k_digest_size);
+
+// in: iterator pair, out: contaner
+picosha2::hash256(src_str.begin(), src_str.end(), hash);
+```
+
+```c++
+std::string src_str = "The quick brown fox jumps over the lazy dog";
+unsigned char hash_byte_c_array[picosha2::k_digest_size];
+// in: container, out: iterator(pointer) pair
+picosha2::hash256(src_str, hash_byte_c_array, hash_byte_c_array+picosha2::k_digest_size);
+```
+
+```c++
+std::string src_str = "The quick brown fox jumps over the lazy dog";
+std::vector<unsigned char> hash(picosha2::k_digest_size);
+// in: iterator pair, out: iterator pair
+picosha2::hash256(src_str.begin(), src_str.end(), hash.begin(), hash.end());
+```

--- a/externals/PicoSHA2/example/hasher.cpp
+++ b/externals/PicoSHA2/example/hasher.cpp
@@ -1,0 +1,22 @@
+#include <iostream>
+#include "../picosha2.h"
+
+void CalcAndOutput(const std::string& src){
+	std::cout << "src : \"" << src << "\"\n";
+	std::cout << "hash: " << picosha2::hash256_hex_string(src) << "\n" << std::endl;
+}
+
+int main(int argc, char* argv[])
+{
+	if(argc == 1){
+		CalcAndOutput("");
+	}
+	else{
+		for(int i = 1; i < argc; ++i){
+			CalcAndOutput(argv[i]);
+		}
+	}
+
+    return 0;
+}
+

--- a/externals/PicoSHA2/example/interactive_hasher.cpp
+++ b/externals/PicoSHA2/example/interactive_hasher.cpp
@@ -1,0 +1,26 @@
+#include <iostream>
+#include "../picosha2.h"
+
+int main(int argc, char* argv[])
+{
+	std::cout << "Input freely. To get hash, input \"hash!\". " << std::endl;
+	picosha2::hash256_one_by_one hasher;
+	while(true){
+		hasher.init(); //reset hasher state
+		while(true){
+			std::string line;
+			std::getline(std::cin, line);
+			if(line == "hash!"){
+				break;
+			}
+			hasher.process(line.begin(), line.end());
+		}
+		hasher.finish();
+		std::string hex_str;
+		picosha2::get_hash_hex_string(hasher, hex_str);
+		std::cout << hex_str << std::endl;
+	}
+
+    return 0;
+}
+

--- a/externals/PicoSHA2/picosha2.h
+++ b/externals/PicoSHA2/picosha2.h
@@ -1,0 +1,377 @@
+/*
+The MIT License (MIT)
+
+Copyright (C) 2017 okdshin
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+#ifndef PICOSHA2_H
+#define PICOSHA2_H
+// picosha2:20140213
+
+#ifndef PICOSHA2_BUFFER_SIZE_FOR_INPUT_ITERATOR
+#define PICOSHA2_BUFFER_SIZE_FOR_INPUT_ITERATOR \
+    1048576  //=1024*1024: default is 1MB memory
+#endif
+
+#include <algorithm>
+#include <cassert>
+#include <iterator>
+#include <sstream>
+#include <vector>
+#include <fstream>
+namespace picosha2 {
+typedef unsigned long word_t;
+typedef unsigned char byte_t;
+
+static const size_t k_digest_size = 32;
+
+namespace detail {
+inline byte_t mask_8bit(byte_t x) { return x & 0xff; }
+
+inline word_t mask_32bit(word_t x) { return x & 0xffffffff; }
+
+const word_t add_constant[64] = {
+    0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1,
+    0x923f82a4, 0xab1c5ed5, 0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3,
+    0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174, 0xe49b69c1, 0xefbe4786,
+    0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+    0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147,
+    0x06ca6351, 0x14292967, 0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13,
+    0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85, 0xa2bfe8a1, 0xa81a664b,
+    0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+    0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a,
+    0x5b9cca4f, 0x682e6ff3, 0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208,
+    0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2};
+
+const word_t initial_message_digest[8] = {0x6a09e667, 0xbb67ae85, 0x3c6ef372,
+                                          0xa54ff53a, 0x510e527f, 0x9b05688c,
+                                          0x1f83d9ab, 0x5be0cd19};
+
+inline word_t ch(word_t x, word_t y, word_t z) { return (x & y) ^ ((~x) & z); }
+
+inline word_t maj(word_t x, word_t y, word_t z) {
+    return (x & y) ^ (x & z) ^ (y & z);
+}
+
+inline word_t rotr(word_t x, std::size_t n) {
+    assert(n < 32);
+    return mask_32bit((x >> n) | (x << (32 - n)));
+}
+
+inline word_t bsig0(word_t x) { return rotr(x, 2) ^ rotr(x, 13) ^ rotr(x, 22); }
+
+inline word_t bsig1(word_t x) { return rotr(x, 6) ^ rotr(x, 11) ^ rotr(x, 25); }
+
+inline word_t shr(word_t x, std::size_t n) {
+    assert(n < 32);
+    return x >> n;
+}
+
+inline word_t ssig0(word_t x) { return rotr(x, 7) ^ rotr(x, 18) ^ shr(x, 3); }
+
+inline word_t ssig1(word_t x) { return rotr(x, 17) ^ rotr(x, 19) ^ shr(x, 10); }
+
+template <typename RaIter1, typename RaIter2>
+void hash256_block(RaIter1 message_digest, RaIter2 first, RaIter2 last) {
+    assert(first + 64 == last);
+    static_cast<void>(last);  // for avoiding unused-variable warning
+    word_t w[64];
+    std::fill(w, w + 64, 0);
+    for (std::size_t i = 0; i < 16; ++i) {
+        w[i] = (static_cast<word_t>(mask_8bit(*(first + i * 4))) << 24) |
+               (static_cast<word_t>(mask_8bit(*(first + i * 4 + 1))) << 16) |
+               (static_cast<word_t>(mask_8bit(*(first + i * 4 + 2))) << 8) |
+               (static_cast<word_t>(mask_8bit(*(first + i * 4 + 3))));
+    }
+    for (std::size_t i = 16; i < 64; ++i) {
+        w[i] = mask_32bit(ssig1(w[i - 2]) + w[i - 7] + ssig0(w[i - 15]) +
+                          w[i - 16]);
+    }
+
+    word_t a = *message_digest;
+    word_t b = *(message_digest + 1);
+    word_t c = *(message_digest + 2);
+    word_t d = *(message_digest + 3);
+    word_t e = *(message_digest + 4);
+    word_t f = *(message_digest + 5);
+    word_t g = *(message_digest + 6);
+    word_t h = *(message_digest + 7);
+
+    for (std::size_t i = 0; i < 64; ++i) {
+        word_t temp1 = h + bsig1(e) + ch(e, f, g) + add_constant[i] + w[i];
+        word_t temp2 = bsig0(a) + maj(a, b, c);
+        h = g;
+        g = f;
+        f = e;
+        e = mask_32bit(d + temp1);
+        d = c;
+        c = b;
+        b = a;
+        a = mask_32bit(temp1 + temp2);
+    }
+    *message_digest += a;
+    *(message_digest + 1) += b;
+    *(message_digest + 2) += c;
+    *(message_digest + 3) += d;
+    *(message_digest + 4) += e;
+    *(message_digest + 5) += f;
+    *(message_digest + 6) += g;
+    *(message_digest + 7) += h;
+    for (std::size_t i = 0; i < 8; ++i) {
+        *(message_digest + i) = mask_32bit(*(message_digest + i));
+    }
+}
+
+}  // namespace detail
+
+template <typename InIter>
+void output_hex(InIter first, InIter last, std::ostream& os) {
+    os.setf(std::ios::hex, std::ios::basefield);
+    while (first != last) {
+        os.width(2);
+        os.fill('0');
+        os << static_cast<unsigned int>(*first);
+        ++first;
+    }
+    os.setf(std::ios::dec, std::ios::basefield);
+}
+
+template <typename InIter>
+void bytes_to_hex_string(InIter first, InIter last, std::string& hex_str) {
+    std::ostringstream oss;
+    output_hex(first, last, oss);
+    hex_str.assign(oss.str());
+}
+
+template <typename InContainer>
+void bytes_to_hex_string(const InContainer& bytes, std::string& hex_str) {
+    bytes_to_hex_string(bytes.begin(), bytes.end(), hex_str);
+}
+
+template <typename InIter>
+std::string bytes_to_hex_string(InIter first, InIter last) {
+    std::string hex_str;
+    bytes_to_hex_string(first, last, hex_str);
+    return hex_str;
+}
+
+template <typename InContainer>
+std::string bytes_to_hex_string(const InContainer& bytes) {
+    std::string hex_str;
+    bytes_to_hex_string(bytes, hex_str);
+    return hex_str;
+}
+
+class hash256_one_by_one {
+   public:
+    hash256_one_by_one() { init(); }
+
+    void init() {
+        buffer_.clear();
+        std::fill(data_length_digits_, data_length_digits_ + 4, 0);
+        std::copy(detail::initial_message_digest,
+                  detail::initial_message_digest + 8, h_);
+    }
+
+    template <typename RaIter>
+    void process(RaIter first, RaIter last) {
+        add_to_data_length(static_cast<word_t>(std::distance(first, last)));
+        std::copy(first, last, std::back_inserter(buffer_));
+        std::size_t i = 0;
+        for (; i + 64 <= buffer_.size(); i += 64) {
+            detail::hash256_block(h_, buffer_.begin() + i,
+                                  buffer_.begin() + i + 64);
+        }
+        buffer_.erase(buffer_.begin(), buffer_.begin() + i);
+    }
+
+    void finish() {
+        byte_t temp[64];
+        std::fill(temp, temp + 64, 0);
+        std::size_t remains = buffer_.size();
+        std::copy(buffer_.begin(), buffer_.end(), temp);
+        temp[remains] = 0x80;
+
+        if (remains > 55) {
+            std::fill(temp + remains + 1, temp + 64, 0);
+            detail::hash256_block(h_, temp, temp + 64);
+            std::fill(temp, temp + 64 - 4, 0);
+        } else {
+            std::fill(temp + remains + 1, temp + 64 - 4, 0);
+        }
+
+        write_data_bit_length(&(temp[56]));
+        detail::hash256_block(h_, temp, temp + 64);
+    }
+
+    template <typename OutIter>
+    void get_hash_bytes(OutIter first, OutIter last) const {
+        for (const word_t* iter = h_; iter != h_ + 8; ++iter) {
+            for (std::size_t i = 0; i < 4 && first != last; ++i) {
+                *(first++) = detail::mask_8bit(
+                    static_cast<byte_t>((*iter >> (24 - 8 * i))));
+            }
+        }
+    }
+
+   private:
+    void add_to_data_length(word_t n) {
+        word_t carry = 0;
+        data_length_digits_[0] += n;
+        for (std::size_t i = 0; i < 4; ++i) {
+            data_length_digits_[i] += carry;
+            if (data_length_digits_[i] >= 65536u) {
+                carry = data_length_digits_[i] >> 16;
+                data_length_digits_[i] &= 65535u;
+            } else {
+                break;
+            }
+        }
+    }
+    void write_data_bit_length(byte_t* begin) {
+        word_t data_bit_length_digits[4];
+        std::copy(data_length_digits_, data_length_digits_ + 4,
+                  data_bit_length_digits);
+
+        // convert byte length to bit length (multiply 8 or shift 3 times left)
+        word_t carry = 0;
+        for (std::size_t i = 0; i < 4; ++i) {
+            word_t before_val = data_bit_length_digits[i];
+            data_bit_length_digits[i] <<= 3;
+            data_bit_length_digits[i] |= carry;
+            data_bit_length_digits[i] &= 65535u;
+            carry = (before_val >> (16 - 3)) & 65535u;
+        }
+
+        // write data_bit_length
+        for (int i = 3; i >= 0; --i) {
+            (*begin++) = static_cast<byte_t>(data_bit_length_digits[i] >> 8);
+            (*begin++) = static_cast<byte_t>(data_bit_length_digits[i]);
+        }
+    }
+    std::vector<byte_t> buffer_;
+    word_t data_length_digits_[4];  // as 64bit integer (16bit x 4 integer)
+    word_t h_[8];
+};
+
+inline void get_hash_hex_string(const hash256_one_by_one& hasher,
+                                std::string& hex_str) {
+    byte_t hash[k_digest_size];
+    hasher.get_hash_bytes(hash, hash + k_digest_size);
+    return bytes_to_hex_string(hash, hash + k_digest_size, hex_str);
+}
+
+inline std::string get_hash_hex_string(const hash256_one_by_one& hasher) {
+    std::string hex_str;
+    get_hash_hex_string(hasher, hex_str);
+    return hex_str;
+}
+
+namespace impl {
+template <typename RaIter, typename OutIter>
+void hash256_impl(RaIter first, RaIter last, OutIter first2, OutIter last2, int,
+                  std::random_access_iterator_tag) {
+    hash256_one_by_one hasher;
+    // hasher.init();
+    hasher.process(first, last);
+    hasher.finish();
+    hasher.get_hash_bytes(first2, last2);
+}
+
+template <typename InputIter, typename OutIter>
+void hash256_impl(InputIter first, InputIter last, OutIter first2,
+                  OutIter last2, int buffer_size, std::input_iterator_tag) {
+    std::vector<byte_t> buffer(buffer_size);
+    hash256_one_by_one hasher;
+    // hasher.init();
+    while (first != last) {
+        int size = buffer_size;
+        for (int i = 0; i != buffer_size; ++i, ++first) {
+            if (first == last) {
+                size = i;
+                break;
+            }
+            buffer[i] = *first;
+        }
+        hasher.process(buffer.begin(), buffer.begin() + size);
+    }
+    hasher.finish();
+    hasher.get_hash_bytes(first2, last2);
+}
+}
+
+template <typename InIter, typename OutIter>
+void hash256(InIter first, InIter last, OutIter first2, OutIter last2,
+             int buffer_size = PICOSHA2_BUFFER_SIZE_FOR_INPUT_ITERATOR) {
+    picosha2::impl::hash256_impl(
+        first, last, first2, last2, buffer_size,
+        typename std::iterator_traits<InIter>::iterator_category());
+}
+
+template <typename InIter, typename OutContainer>
+void hash256(InIter first, InIter last, OutContainer& dst) {
+    hash256(first, last, dst.begin(), dst.end());
+}
+
+template <typename InContainer, typename OutIter>
+void hash256(const InContainer& src, OutIter first, OutIter last) {
+    hash256(src.begin(), src.end(), first, last);
+}
+
+template <typename InContainer, typename OutContainer>
+void hash256(const InContainer& src, OutContainer& dst) {
+    hash256(src.begin(), src.end(), dst.begin(), dst.end());
+}
+
+template <typename InIter>
+void hash256_hex_string(InIter first, InIter last, std::string& hex_str) {
+    byte_t hashed[k_digest_size];
+    hash256(first, last, hashed, hashed + k_digest_size);
+    std::ostringstream oss;
+    output_hex(hashed, hashed + k_digest_size, oss);
+    hex_str.assign(oss.str());
+}
+
+template <typename InIter>
+std::string hash256_hex_string(InIter first, InIter last) {
+    std::string hex_str;
+    hash256_hex_string(first, last, hex_str);
+    return hex_str;
+}
+
+inline void hash256_hex_string(const std::string& src, std::string& hex_str) {
+    hash256_hex_string(src.begin(), src.end(), hex_str);
+}
+
+template <typename InContainer>
+void hash256_hex_string(const InContainer& src, std::string& hex_str) {
+    hash256_hex_string(src.begin(), src.end(), hex_str);
+}
+
+template <typename InContainer>
+std::string hash256_hex_string(const InContainer& src) {
+    return hash256_hex_string(src.begin(), src.end());
+}
+template<typename OutIter>void hash256(std::ifstream& f, OutIter first, OutIter last){
+    hash256(std::istreambuf_iterator<char>(f), std::istreambuf_iterator<char>(), first,last);
+
+}
+}// namespace picosha2
+#endif  // PICOSHA2_H

--- a/externals/PicoSHA2/picosha2.h
+++ b/externals/PicoSHA2/picosha2.h
@@ -93,7 +93,7 @@ void hash256_block(RaIter1 message_digest, RaIter2 first, RaIter2 last) {
     assert(first + 64 == last);
     static_cast<void>(last);  // for avoiding unused-variable warning
     word_t w[64];
-    std::fill(w, w + 64, 0);
+    std::fill(w, w + 64, word_t(0));
     for (std::size_t i = 0; i < 16; ++i) {
         w[i] = (static_cast<word_t>(mask_8bit(*(first + i * 4))) << 24) |
                (static_cast<word_t>(mask_8bit(*(first + i * 4 + 1))) << 16) |
@@ -204,17 +204,17 @@ class hash256_one_by_one {
 
     void finish() {
         byte_t temp[64];
-        std::fill(temp, temp + 64, 0);
+        std::fill(temp, temp + 64, byte_t(0));
         std::size_t remains = buffer_.size();
         std::copy(buffer_.begin(), buffer_.end(), temp);
         temp[remains] = 0x80;
 
         if (remains > 55) {
-            std::fill(temp + remains + 1, temp + 64, 0);
+            std::fill(temp + remains + 1, temp + 64, byte_t(0));
             detail::hash256_block(h_, temp, temp + 64);
-            std::fill(temp, temp + 64 - 4, 0);
+            std::fill(temp, temp + 64 - 4, byte_t(0));
         } else {
-            std::fill(temp + remains + 1, temp + 64 - 4, 0);
+            std::fill(temp + remains + 1, temp + 64 - 4, byte_t(0));
         }
 
         write_data_bit_length(&(temp[56]));

--- a/externals/PicoSHA2/test/test.cpp
+++ b/externals/PicoSHA2/test/test.cpp
@@ -1,0 +1,255 @@
+#include "../picosha2.h"
+#include <iostream>
+#include <list>
+#include <fstream>
+
+#define PICOSHA2_CHECK_EQUAL(a, b){\
+    if(a == b){\
+        std::cout << "\033[32m" << __FUNCTION__ << "(LINE:" << __LINE__ << ") is succeeded." << "\033[39m" << std::endl;\
+    }\
+    else{\
+        std::cout << "\033[31m" << __FUNCTION__ << "(LINE:" << __LINE__ << ") is failed.\n\t" << #a << " != " << #b \
+        << "\033[39m" << std::endl;\
+    }\
+}
+#define PICOSHA2_CHECK_EQUAL_BYTES(a, b){\
+    if(is_same_bytes(a, b)){\
+        std::cout << "\033[32m" << __FUNCTION__ << "(LINE:" << __LINE__ << ") is succeeded." << "\033[39m" << std::endl;\
+    }\
+    else{\
+        std::cout << "\033[31m" << __FUNCTION__ << "(LINE:" << __LINE__ << ") is failed.\n\t" << #a << " != " << #b \
+        << "\033[39m" << std::endl;\
+    }\
+}
+
+template<typename InIter1, typename InIter2>
+bool is_same_bytes(InIter1 first1, InIter1 last1, InIter2 first2, InIter2 last2){
+    if(std::distance(first1, last1) != std::distance(first2, last2)){
+        return false;
+    }
+    return std::search(first1, last1, first2, last2) != last1;
+}
+
+template<typename InContainer1, typename InContainer2>
+bool is_same_bytes(const InContainer1& bytes1, const InContainer2& bytes2){
+    return is_same_bytes(bytes1.begin(), bytes1.end(), bytes2.begin(), bytes2.end());
+}
+
+template<typename OutIter>
+void input_hex(std::istream& is, OutIter first, OutIter last){
+    char c;
+    std::vector<char> buffer;
+    while(first != last){
+        if(buffer.size() == 2){
+            *(first++) = (buffer.front()*16+buffer.back());
+            buffer.clear();
+        }
+        is >> c;
+        if('0' <= c && c <= '9'){
+            buffer.push_back(c-'0');
+        }else
+        if('a' <= c && c <= 'f'){
+            buffer.push_back(c-'a'+10); 
+        }
+    }
+}
+
+template<typename OutIter>
+void hex_string_to_bytes(const std::string& hex_str, OutIter first, OutIter last){
+    assert(hex_str.length() >= 2*std::distance(first, last));
+    std::istringstream iss(hex_str);
+    input_hex(iss, first, last);
+}
+
+template<typename OutContainer>
+void hex_string_to_bytes(const std::string& hex_str, OutContainer& bytes){
+    hex_string_to_bytes(hex_str, bytes.begin(), bytes.end());
+}
+
+typedef std::pair<std::string, std::string> mess_and_hash;
+const size_t sample_size = 10;
+const std::pair<std::string, std::string> sample_message_list[sample_size] = {
+    mess_and_hash("", 
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"),
+    mess_and_hash("The quick brown fox jumps over the lazy dog",
+            "d7a8fbb307d7809469ca9abcb0082e4f8d5651e46d3cdb762d02d0bf37c9e592"),
+    mess_and_hash("The quick brown fox jumps over the lazy dog.",
+            "ef537f25c895bfa782526529a9b63d97aa631564d5d789c2b765448c8635fb6c"),
+    mess_and_hash("For this sample, this 63-byte string will be used as input data",
+            "f08a78cbbaee082b052ae0708f32fa1e50c5c421aa772ba5dbb406a2ea6be342"),
+    mess_and_hash("abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq",
+            "248d6a61d20638b8e5c026930c3e6039a33ce45964ff2167f6ecedd419db06c1"),
+    mess_and_hash("This is exactly 64 bytes long, not counting the terminating byte",
+            "ab64eff7e88e2e46165e29f2bce41826bd4c7b3552f6b382a9e7d3af47c245f8"),
+    mess_and_hash("This is exactly 64 bytes long, not counting the terminati",
+            "46db250ef6d667908de17333c25343778f495d7a8010b9cfa2af97940772e8cd"),
+    mess_and_hash("This is exactly 64 bytes long, not counting the terminatin",
+            "af38fc14dbbbcc6cd4c9cc73988e1b08373b4e6b04ba61b41f999731185b51af"),
+    mess_and_hash("This is exactly 64 bytes long, not counting the terminating",
+            "f778b361f650cdd9981ca13adb77f26b8419a407b3938fc54b14e9971045fa9d"),
+    mess_and_hash("This is exactly 64 bytes long, not counting the terminating b",
+            "9aa72d139c7d7e5a35ea525e2ba6704163555ba647927765a61ccbf12ec60479")
+};
+
+void test(){
+    for(std::size_t i = 0; i < sample_size; ++i){
+        std::string src_str = sample_message_list[i].first;
+        std::cout << "src_str: " << src_str  << " size: " << src_str.length() << std::endl;
+        std::string ans_hex_str = sample_message_list[i].second;
+        std::vector<unsigned char> ans(picosha2::k_digest_size);
+        hex_string_to_bytes(ans_hex_str, ans);
+        {
+            std::vector<unsigned char> hash(picosha2::k_digest_size);
+            picosha2::hash256(src_str.begin(), src_str.end(), hash.begin(), hash.end());
+            PICOSHA2_CHECK_EQUAL_BYTES(ans, hash);
+        }
+        {
+            std::vector<unsigned char> hash(picosha2::k_digest_size);
+            picosha2::hash256(src_str, hash);
+            PICOSHA2_CHECK_EQUAL_BYTES(ans, hash);
+        }
+        {
+            std::vector<unsigned char> hash(picosha2::k_digest_size);
+            picosha2::hash256(src_str.begin(), src_str.end(), hash);
+            PICOSHA2_CHECK_EQUAL_BYTES(ans, hash);
+        }
+        {
+            unsigned char hash_c_array[picosha2::k_digest_size];
+            picosha2::hash256(src_str.begin(), src_str.end(), hash_c_array, hash_c_array+picosha2::k_digest_size);
+            std::vector<unsigned char> hash(hash_c_array, hash_c_array+picosha2::k_digest_size);
+            PICOSHA2_CHECK_EQUAL_BYTES(ans, hash);
+        }
+        {
+            std::list<unsigned char> hash(picosha2::k_digest_size);
+            picosha2::hash256(src_str.begin(), src_str.end(), hash.begin(), hash.end());
+            PICOSHA2_CHECK_EQUAL_BYTES(ans, hash);
+        }
+        {
+            std::list<unsigned char> hash(picosha2::k_digest_size);
+            picosha2::hash256(src_str, hash);
+            PICOSHA2_CHECK_EQUAL_BYTES(ans, hash);
+        }
+        {
+            std::string hash_hex_str;
+            picosha2::hash256_hex_string(src_str.begin(), src_str.end(), hash_hex_str);
+            PICOSHA2_CHECK_EQUAL(ans_hex_str, hash_hex_str);
+        }
+        {
+            std::string hash_hex_str;
+            picosha2::hash256_hex_string(src_str, hash_hex_str);
+            PICOSHA2_CHECK_EQUAL(ans_hex_str, hash_hex_str);
+        }
+        {
+            std::string hash_hex_str = 
+                picosha2::hash256_hex_string(src_str.begin(), src_str.end());
+            PICOSHA2_CHECK_EQUAL(ans_hex_str, hash_hex_str);
+        }
+        {
+            std::string hash_hex_str = picosha2::hash256_hex_string(src_str);
+            PICOSHA2_CHECK_EQUAL(ans_hex_str, hash_hex_str);
+        }
+        
+        std::vector<unsigned char> src_vect(src_str.begin(), src_str.end());
+        {
+            std::vector<unsigned char> hash(picosha2::k_digest_size);
+            picosha2::hash256(src_vect.begin(), src_vect.end(), hash.begin(), hash.end());
+            PICOSHA2_CHECK_EQUAL_BYTES(ans, hash);
+        }
+        {
+            std::vector<unsigned char> hash(picosha2::k_digest_size);
+            picosha2::hash256(src_vect, hash);
+            PICOSHA2_CHECK_EQUAL_BYTES(ans, hash);
+        }
+        {
+            std::list<unsigned char> hash(picosha2::k_digest_size);
+            picosha2::hash256(src_vect.begin(), src_vect.end(), hash.begin(), hash.end());
+            PICOSHA2_CHECK_EQUAL_BYTES(ans, hash);
+        }
+        {
+            std::list<unsigned char> hash(picosha2::k_digest_size);
+            picosha2::hash256(src_vect.data(), src_vect.data()+src_vect.size(), 
+                    hash.begin(), hash.end());
+            PICOSHA2_CHECK_EQUAL_BYTES(ans, hash);
+        }
+        {
+            std::list<unsigned char> hash(picosha2::k_digest_size);
+            picosha2::hash256(src_vect, hash);
+            PICOSHA2_CHECK_EQUAL_BYTES(ans, hash);
+        }
+        {
+            std::string hash_hex_str;
+            picosha2::hash256_hex_string(src_vect.begin(), src_vect.end(), hash_hex_str);
+            PICOSHA2_CHECK_EQUAL(ans_hex_str, hash_hex_str);
+        }
+        {
+            std::string hash_hex_str;
+            picosha2::hash256_hex_string(src_vect, hash_hex_str);
+            PICOSHA2_CHECK_EQUAL(ans_hex_str, hash_hex_str);
+        }
+        {
+            std::string hash_hex_str = 
+                picosha2::hash256_hex_string(src_vect.begin(), src_vect.end());
+            PICOSHA2_CHECK_EQUAL(ans_hex_str, hash_hex_str);
+        }
+        {
+            std::string hash_hex_str = picosha2::hash256_hex_string(src_vect);
+            PICOSHA2_CHECK_EQUAL(ans_hex_str, hash_hex_str);
+        }
+        {
+            std::list<char> src(src_str.begin(), src_str.end());
+            std::vector<unsigned char> hash(picosha2::k_digest_size);
+            picosha2::hash256(src.begin(), src.end(), hash.begin(), hash.end());
+            PICOSHA2_CHECK_EQUAL_BYTES(ans, hash);
+        }
+    }
+    {
+        picosha2::hash256_one_by_one hasher;
+        std::ifstream ifs("test.cpp");
+        std::string file_str((std::istreambuf_iterator<char>(ifs)), 
+                std::istreambuf_iterator<char>());
+        std::size_t i = 0;
+        std::size_t block_size = file_str.length()/10;
+        for(i = 0; i+block_size <= file_str.length(); i+=block_size){
+            hasher.process(file_str.begin()+i, file_str.begin()+i+block_size);
+        }
+        hasher.process(file_str.begin()+i, file_str.end());
+        hasher.finish();
+        std::string one_by_one_hex_string;
+        get_hash_hex_string(hasher, one_by_one_hex_string);
+
+        std::string hex_string;
+        picosha2::hash256_hex_string(file_str.begin(), file_str.end(), hex_string);
+        PICOSHA2_CHECK_EQUAL(one_by_one_hex_string, hex_string);
+
+    }
+    {
+        std::string one_by_one_hex_string; {
+            picosha2::hash256_one_by_one hasher;
+            std::ifstream ifs("test.cpp");
+            std::string file_str((std::istreambuf_iterator<char>(ifs)), 
+                    std::istreambuf_iterator<char>());
+            std::size_t i = 0;
+            std::size_t block_size = file_str.length()/10;
+            for(i = 0; i+block_size <= file_str.length(); i+=block_size){
+                hasher.process(file_str.begin()+i, file_str.begin()+i+block_size);
+            }
+            hasher.process(file_str.begin()+i, file_str.end());
+            hasher.finish();
+            get_hash_hex_string(hasher, one_by_one_hex_string);
+        }
+
+        std::ifstream ifs("test.cpp");
+        auto first = std::istreambuf_iterator<char>(ifs);
+        auto last = std::istreambuf_iterator<char>();
+        auto hex_string = picosha2::hash256_hex_string(first, last);
+        PICOSHA2_CHECK_EQUAL(one_by_one_hex_string, hex_string);
+    }
+}
+
+int main(int argc, char* argv[])
+{
+    test();
+
+    return 0;
+}
+

--- a/sources/CMakeLists.txt
+++ b/sources/CMakeLists.txt
@@ -4,7 +4,7 @@ endif()
 
 configure_file(GeneratedConstants.hpp.in "${CMAKE_CURRENT_BINARY_DIR}/GeneratedConstants.hpp")
 add_executable(rescom main.cpp Configuration.hpp LegacyCppCodeGenerator.cpp LegacyCppCodeGenerator.hpp StringHelpers.hpp StringHelpers.cpp ${CMAKE_CURRENT_BINARY_DIR}/GeneratedConstants.hpp FileSystem.cpp FileSystem.hpp ConfigurationParser.cpp ConfigurationParser.hpp CodeGenerator.cpp CodeGenerator.hpp)
-target_link_libraries(rescom PRIVATE cxxopts)
+target_link_libraries(rescom PRIVATE cxxopts PicoSHA2)
 target_include_directories(rescom PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 set_target_properties(rescom PROPERTIES CXX_STANDARD 17 CXX_EXTENSIONS ON CXX_STANDARD_REQUIRED ON)
 warning_as_error(rescom)

--- a/sources/main.cpp
+++ b/sources/main.cpp
@@ -6,6 +6,8 @@
 
 #include <cxxopts.hpp>
 
+#include <picosha2.h>
+
 #include "Configuration.hpp"
 #include "LegacyCppCodeGenerator.hpp"
 #include "GeneratedConstants.hpp"
@@ -33,6 +35,70 @@ CodeGeneratorPointer createGenerator(cxxopts::ParseResult const& parseResult, Co
         return instanciateCodeGenerator(parseResult["generator"].as<std::string>(), configuration);
 }
 
+std::optional<std::filesystem::path> getFilePath(cxxopts::ParseResult const& parseResults, std::string const& key)
+{
+    if (parseResults.count(key) > 0)
+        return parseResults[key].as<std::string>();
+    return {};
+}
+
+std::vector<std::string> computeInputHashes(Configuration const& configuration)
+{
+    std::vector<std::string> actualHashes;
+
+    for (auto const& input : configuration.inputs)
+    {
+        std::ifstream ifstream(input.filePath, std::ios::in);
+
+        if (!ifstream.is_open())
+            throw std::runtime_error("Unable to open input file for reading '" + input.filePath.generic_string() + "'");
+
+        std::vector<char> buffer;
+
+        std::copy(std::istream_iterator<char>(ifstream), std::istream_iterator<char>{}, std::back_inserter(buffer));
+        actualHashes.push_back(picosha2::hash256_hex_string(buffer));
+    }
+
+    return actualHashes;
+}
+
+std::vector<std::string> readHashesFile(std::filesystem::path const& filePath)
+{
+    std::ifstream file{filePath, std::ios::in};
+
+    if (!file.is_open())
+        throw std::runtime_error("unable to read file '" + filePath.generic_string() + "'");
+
+    std::istream_iterator<std::string> inputIt{file};
+    std::istream_iterator<std::string> endInputIt;
+    std::vector<std::string> lines;
+
+    std::copy(inputIt, endInputIt, std::back_inserter(lines));
+
+    return lines;
+}
+
+void writeHashesFile(std::filesystem::path const& filePath, std::vector<std::string> const& hashes)
+{
+    std::ofstream file{filePath, std::ios::out | std::ios::trunc};
+
+    if (!file.is_open())
+        throw std::runtime_error("unable to write file '" + filePath.generic_string() + "'");
+
+    std::copy(hashes.begin(), hashes.end(), std::ostream_iterator<std::string>(file, "\n"));
+}
+
+bool skip(Configuration const& configuration, std::filesystem::path const& witnessFilePath)
+{
+    auto previousHashes = readHashesFile(witnessFilePath);
+
+    std::vector<std::string> const actualHashes = computeInputHashes(configuration);
+
+    writeHashesFile(witnessFilePath, actualHashes);
+
+    return previousHashes == actualHashes;
+}
+
 int main(int argc, char** argv)
 {
     registerCodeGenerators();
@@ -45,6 +111,7 @@ int main(int argc, char** argv)
         ("o,output", "Output file", cxxopts::value<std::string>())
         ("G,generator", "Generator", cxxopts::value<std::string>())
         ("version", "Print version", cxxopts::value<bool>())
+        ("witness", "Witness file", cxxopts::value<std::string>())
         ;
 
     auto parseResult = options.parse(argc, argv);
@@ -56,12 +123,20 @@ int main(int argc, char** argv)
     }
 
     std::filesystem::path const inputFilePath{parseResult["input"].as<std::string>()};
+    std::optional<std::filesystem::path> witnessFilePath{getFilePath(parseResult, "witness")};
     std::ostringstream outputStream;
 
     try
     {
         ConfigurationParser parser{std::make_unique<LocalFileSystem>()};
         auto configuration = parser.parseFile(inputFilePath);
+
+        if (witnessFilePath.has_value() && skip(configuration, *witnessFilePath))
+        {
+            std::cout << "Nothing changed\n";
+            return 0;
+        }
+
         auto generator = createGenerator(parseResult, configuration);
 
         if (generator != nullptr)

--- a/sources/main.cpp
+++ b/sources/main.cpp
@@ -64,6 +64,9 @@ std::vector<std::string> computeInputHashes(Configuration const& configuration)
 
 std::vector<std::string> readHashesFile(std::filesystem::path const& filePath)
 {
+    if (!std::filesystem::exists(filePath))
+        return {};
+
     std::ifstream file{filePath, std::ios::in};
 
     if (!file.is_open())

--- a/sources/main.cpp
+++ b/sources/main.cpp
@@ -136,7 +136,7 @@ int main(int argc, char** argv)
 
         if (witnessFilePath.has_value() && skip(configuration, *witnessFilePath))
         {
-            std::cout << "Nothing changed\n";
+            // Nothing changed since the last run.
             return 0;
         }
 

--- a/sources/main.cpp
+++ b/sources/main.cpp
@@ -101,33 +101,33 @@ bool skip(Configuration const& configuration, std::filesystem::path const& witne
 
 int main(int argc, char** argv)
 {
-    registerCodeGenerators();
-
-    std::vector<std::string> inputs;
-    cxxopts::Options options("rescom", "Resources compiler");
-
-    options.add_options()
-        ("i,input", "Input file", cxxopts::value<std::string>())
-        ("o,output", "Output file", cxxopts::value<std::string>())
-        ("G,generator", "Generator", cxxopts::value<std::string>())
-        ("version", "Print version", cxxopts::value<bool>())
-        ("witness", "Witness file", cxxopts::value<std::string>())
-        ;
-
-    auto parseResult = options.parse(argc, argv);
-
-    if (parseResult["version"].count() > 0)
-    {
-        std::cout << "rescom version " << RescomVersion << "\n";
-        return 0;
-    }
-
-    std::filesystem::path const inputFilePath{parseResult["input"].as<std::string>()};
-    std::optional<std::filesystem::path> witnessFilePath{getFilePath(parseResult, "witness")};
-    std::ostringstream outputStream;
-
     try
     {
+        registerCodeGenerators();
+
+        std::vector<std::string> inputs;
+        cxxopts::Options options("rescom", "Resources compiler");
+
+        options.add_options()
+            ("i,input", "Input file", cxxopts::value<std::string>())
+            ("o,output", "Output file", cxxopts::value<std::string>())
+            ("G,generator", "Generator", cxxopts::value<std::string>())
+            ("version", "Print version", cxxopts::value<bool>())
+            ("witness", "Witness file", cxxopts::value<std::string>())
+            ;
+
+        auto parseResult = options.parse(argc, argv);
+
+        if (parseResult["version"].count() > 0)
+        {
+            std::cout << "rescom version " << RescomVersion << "\n";
+            return 0;
+        }
+
+        std::filesystem::path const inputFilePath{parseResult["input"].as<std::string>()};
+        std::optional<std::filesystem::path> witnessFilePath{getFilePath(parseResult, "witness")};
+        std::ostringstream outputStream;
+
         ConfigurationParser parser{std::make_unique<LocalFileSystem>()};
         auto configuration = parser.parseFile(inputFilePath);
 


### PR DESCRIPTION
This behavior is enabled by using the flag --witness <witness file>.
A witness file contains the list of the hashes (SHA2) of each input files.